### PR TITLE
Fix ivy extension on linux: TW-37515 is finally fixed on buildserver

### DIFF
--- a/build.idea.common.xml
+++ b/build.idea.common.xml
@@ -68,9 +68,8 @@
     </target>
 
     <target name="idea-properties-linux" if="idea-for-linux">
-        <!-- Waiting for TW-37515 fix to be deployed on buildserver, then extension should be changed to .tar.gz-->
-        <property name="idea-ext" value="gz"/>
-        <property name="idea-infix-ivy" value="(\.tar)?" />
+        <property name="idea-ext" value="tar.gz"/>
+        <property name="idea-infix-ivy" value="" />
         <property name="idea-vmo" value="${idea-lin-vmoptions}"/>
         <property name="idea-vmo64" value="${idea-lin-vmoptions64}"/>
         <property name="idea-patch-home" value="${idea-unpack}" />

--- a/build.idea.fetch.xml
+++ b/build.idea.fetch.xml
@@ -10,7 +10,6 @@
 
 
     <target name="update-idea-fetch" depends="idea-properties, update-idea-recreate-temp">
-        <!-- Waiting for TW-37515 fix to be deployed on buildserver, then '(\.tar)?' can be removed-->
         <echo file="${idea-temp}/ivy.xml"><![CDATA[
             <ivy-module version="1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://incubator.apache.org/ivy/schemas/ivy.xsd">
                 <info organisation="Jetbrains" module="TeamCity"/>


### PR DESCRIPTION
In 'ivy.xml' there no more files with extension 'gz' only 'tar.gz'
